### PR TITLE
[docs] Add dev-env to Projects table

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ changes rather than one-off experiments.
 
 | Repo | Status | Description |
 |---|---|---|
+| [`dev-env`](https://github.com/brownm09/dev-env) | Active | Cross-device development environment: Claude Code global config, hooks, custom skills (`/propose`, `/journal-compose`, `/research`), and document templates. |
 | [`lifting-logbook`](https://github.com/brownm09/lifting-logbook) | In Progress | Training log with AI-driven recommendations based on performance, sleep, and nutrition. |
 
 ### Playbooks


### PR DESCRIPTION
Adds `dev-env` as the first entry in the Projects table with a description covering its config, hooks, skills, and templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)