### PR TITLE
Update leadership-playbooks status and link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ changes rather than one-off experiments.
 | Repo | Status | Description |
 |---|---|---|
 | [`engineering-playbooks`](https://github.com/brownm09/engineering-playbooks) | In Progress | Systematized frameworks from real work: DR fire drills, on-call restructuring, PCI gap analysis, CI/CD governance, and LaunchDarkly rollout templates. |
-| `leadership-playbooks` | Planned | Management tools and procedures for engineering leaders: hiring rubrics, performance frameworks, org design, and 1:1 structures. |
+| [`leadership-playbooks`](https://github.com/brownm09/leadership-playbooks) | In Progress | Leadership process playbooks: PRD lifecycle management, AI documentation standards, org design, and stakeholder communication frameworks. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds hyperlink to `leadership-playbooks` repo (was plain text)
- Updates status from `Planned` to `In Progress`
- Updates description to reflect actual content (prd-lifecycle, ai-documentation-standards)

## Test plan
- [ ] Verify link resolves to correct repo
- [ ] Verify README renders correctly on github.com/brownm09

🤖 Generated with [Claude Code](https://claude.com/claude-code)