### PR TITLE
Update profile: consolidate to tech-leadership-playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ changes rather than one-off experiments.
 
 | Repo | Status | Description |
 |---|---|---|
-| [`engineering-playbooks`](https://github.com/brownm09/engineering-playbooks) | In Progress | Systematized frameworks from real work: DR fire drills, on-call restructuring, PCI gap analysis, CI/CD governance, and LaunchDarkly rollout templates. |
-| [`leadership-playbooks`](https://github.com/brownm09/leadership-playbooks) | In Progress | Leadership process playbooks: PRD lifecycle management, AI documentation standards, org design, and stakeholder communication frameworks. |
+| [`tech-leadership-playbooks`](https://github.com/brownm09/tech-leadership-playbooks) | In Progress | Frameworks spanning engineering operations and leadership process: DR fire drills, on-call restructuring, PCI gap analysis, CI/CD governance, LaunchDarkly rollout templates, org design, career ladders, executive communication, program management, and AI adoption. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Collapses the two Playbooks table rows (`engineering-playbooks` + `leadership-playbooks`) into a single row pointing to [`tech-leadership-playbooks`](https://github.com/brownm09/tech-leadership-playbooks)
- Bundles two earlier commits on this branch (background update, leadership-playbooks link fix) into one PR

## Context

`engineering-playbooks` was renamed to `tech-leadership-playbooks` and `leadership-playbooks` content was migrated into it (PR brownm09/tech-leadership-playbooks#7). The profile README now reflects a single, cohesive playbooks repo rather than an artificial split.

`brownm09/leadership-playbooks` will be archived separately after this merges.

## Test plan

- [ ] Verify profile README shows one Playbooks row linking to `tech-leadership-playbooks`
- [ ] Verify link resolves correctly (GitHub auto-redirects `engineering-playbooks` → `tech-leadership-playbooks`)