### PR TITLE
Tighten profile bio register for director-level search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mike Brown
 
-Engineering leader building platform and developer experience infrastructure in regulated,
+Engineering leader building platform and developer-experience infrastructure in regulated,
 high-volume environments. At ActBlue, the teams I lead process over one million transactions
 per day.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Mike Brown
 
-Engineering leader focused on regulated, high-volume platforms — payments, compliance,
-infrastructure modernization.
+Engineering leader building platform and developer experience infrastructure in regulated,
+high-volume environments. At ActBlue, the teams I lead process over one million transactions
+per day.
 
-I've spent the last decade building and scaling engineering organizations across government,
-fintech, and nonprofit environments: leading teams through PCI-DSS remediation, decomposing
-monolithic architectures, and establishing the CI/CD and observability practices that make those
-migrations survivable. Most recently at ActBlue, where the platform processes over one million
-transactions per day.
+Across government, fintech, and nonprofit contexts, the work has been consistent: reduce the
+friction that slows engineering teams down. That has meant PCI-DSS remediation, monolith
+decomposition, and the CI/CD and observability foundations that make large migrations survivable.
 
-My current focus is on how AI tooling (Claude Code, GitHub Copilot) changes the leverage
-available to engineering teams — and how to roll it out in a way that produces durable workflow
-changes rather than one-off experiments.
+Current focus: using Claude Code and GitHub Copilot to shift the leverage available to
+engineering teams. The goal is durable workflow change, not one-off experiments.
 
 ---
 


### PR DESCRIPTION
## Summary

- Opens on the platform/DevEx differentiator rather than a generic category label
- Moves the 1M transactions/day credential into paragraph 1
- Replaces wind-up openers ("I've spent the last decade...", "My current focus is on...") with declarative heads

## Acceptance criteria

- [x] ≤ 3 short paragraphs
- [x] No wind-up openers
- [x] Friction-reduction organizing principle legible in P2
- [x] 1M transactions/day in P1
- [x] Declarative, precise, first-person retained
- [x] No em-dashes

## Test plan

- [ ] Confirm rendered README on GitHub matches the revised text
- [ ] Verify paragraph breaks and heading render correctly
- [ ] Read against each acceptance criterion above

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)