### PR TITLE
Reframe dev-env description as AI adoption experiment infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Right now, I am working through what Claude Code and GitHub Copilot actually cha
 
 | Repo | Status | Description |
 |---|---|---|
-| [`dev-env`](https://github.com/brownm09/dev-env) | Active | Cross-device development environment: Claude Code global config, hooks, custom skills (`/propose`, `/journal-compose`, `/research`), and document templates. |
+| [`dev-env`](https://github.com/brownm09/dev-env) | Active | The working infrastructure behind the AI adoption experiment: global Claude Code config, workflow automation hooks, custom skills, and scheduled routines. Policy-as-code for a single-operator development environment. |
 | [`lifting-logbook`](https://github.com/brownm09/lifting-logbook) | In Progress | Training log with AI-driven recommendations based on performance, sleep, and nutrition. |
 
 ### Playbooks


### PR DESCRIPTION
## Summary
- Updates the `dev-env` row description in README.md from a feature list to a framing that connects to the bio's AI adoption experiment claim
- Positions dev-env as evidence backing the "experiment in progress" statement, not a tooling inventory
- Adds "policy-as-code" language that maps to the AI adoption framework

## Test plan
- [ ] Verify the updated description reads naturally in context with the rest of the Projects table
- [ ] Confirm the GitHub URL in the row still resolves correctly

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)