### PR TITLE
Fix broken Playbooks link and update tech-leadership-reference description

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Right now, I am working through what Claude Code and GitHub Copilot actually cha
 
 | Repo | Status | Description |
 |---|---|---|
-| [`tech-leadership-playbooks`](https://github.com/brownm09/tech-leadership-playbooks) | In Progress | Frameworks spanning engineering operations and leadership process: DR fire drills, on-call restructuring, PCI gap analysis, CI/CD governance, LaunchDarkly rollout templates, org design, career ladders, executive communication, program management, and AI adoption. |
+| [`tech-leadership-reference`](https://github.com/brownm09/tech-leadership-reference) | In Progress | Operational and leadership frameworks derived from production engineering work: incident response, DR, CI/CD governance, PCI-DSS compliance, org design, career ladders, program management, and AI adoption. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes broken link in Playbooks table: `tech-leadership-playbooks` → `tech-leadership-reference`
- Updates README entry description to accurately reflect the repo's full scope
- Updates GitHub repo description for `tech-leadership-reference` to match

## Test plan
- [ ] Playbooks table link resolves to the correct repo
- [ ] README entry description is concise and accurate
- [ ] GitHub repo description updated

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)