### PR TITLE
Add Purpose column to What's Here tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Right now, I am working through what Claude Code and GitHub Copilot actually cha
 | Repo | Status | Description | Purpose |
 |---|---|---|---|
 | [`dev-env`](https://github.com/brownm09/dev-env) | Active | The working infrastructure behind the AI adoption experiment: global Claude Code config, workflow automation hooks, custom skills, and scheduled routines. Policy-as-code for a single-operator development environment. | Demonstrates the application of systems thinking to developer tooling at a policy-as-code level; establishes where automation ends and engineering judgment begins. |
-| [`lifting-logbook`](https://github.com/brownm09/lifting-logbook) | In Progress | Training log with AI-driven recommendations based on performance, sleep, and nutrition. | Evidence that technical opinions are grounded in current, end-to-end ownership rather than organizational memory. |
+| [`lifting-logbook`](https://github.com/brownm09/lifting-logbook) | In Progress | Training log with AI-driven recommendations based on performance, sleep, and nutrition. | Demonstrates that technical opinions are grounded in current, end-to-end ownership rather than organizational memory. |
 
 ### Playbooks
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Right now, I am working through what Claude Code and GitHub Copilot actually cha
 
 ### Projects
 
-| Repo | Status | Description |
-|---|---|---|
-| [`dev-env`](https://github.com/brownm09/dev-env) | Active | The working infrastructure behind the AI adoption experiment: global Claude Code config, workflow automation hooks, custom skills, and scheduled routines. Policy-as-code for a single-operator development environment. |
-| [`lifting-logbook`](https://github.com/brownm09/lifting-logbook) | In Progress | Training log with AI-driven recommendations based on performance, sleep, and nutrition. |
+| Repo | Status | Description | Purpose |
+|---|---|---|---|
+| [`dev-env`](https://github.com/brownm09/dev-env) | Active | The working infrastructure behind the AI adoption experiment: global Claude Code config, workflow automation hooks, custom skills, and scheduled routines. Policy-as-code for a single-operator development environment. | Demonstrates the application of systems thinking to developer tooling at a policy-as-code level; establishes where automation ends and engineering judgment begins. |
+| [`lifting-logbook`](https://github.com/brownm09/lifting-logbook) | In Progress | Training log with AI-driven recommendations based on performance, sleep, and nutrition. | Evidence that technical opinions are grounded in current, end-to-end ownership rather than organizational memory. |
 
 ### Playbooks
 
-| Repo | Status | Description |
-|---|---|---|
-| [`tech-leadership-reference`](https://github.com/brownm09/tech-leadership-reference) | In Progress | Operational and leadership frameworks derived from production engineering work: incident response, DR, CI/CD governance, PCI-DSS compliance, org design, career ladders, program management, and AI adoption. |
+| Repo | Status | Description | Purpose |
+|---|---|---|---|
+| [`tech-leadership-reference`](https://github.com/brownm09/tech-leadership-reference) | In Progress | Operational and leadership frameworks derived from production engineering work: incident response, DR, CI/CD governance, PCI-DSS compliance, org design, career ladders, program management, and AI adoption. | A primary-source record of operational frameworks applied in production; distinguishes practitioner judgment from general leadership theory. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **Purpose** column to both the Projects and Playbooks tables in the README
- Each entry is one formal sentence explaining what the repo demonstrates about professional judgment or capability, distinct from what the repo contains

## Test plan

- [ ] Both tables render with four columns on the GitHub profile page
- [ ] Purpose language is formal (no contractions, no first person)
- [ ] No other sections modified

Closes #13